### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ script:
     bash -c '                                           \
         java -version                                   \
         && env|sort                                     \
-        && mvn clean verify sonar:sonar                 \
-        && (cd view/ ; mvn sonar:sonar)                 \
-        && (cd model/ ; mvn sonar:sonar)                \
+        && mvn -T 1C clean verify sonar:sonar                 \
+        && (cd view/ ; mvn -T 1C sonar:sonar)                 \
+        && (cd model/ ; mvn -T 1C sonar:sonar)                \
         && (bash <(curl -s https://codecov.io/bash) || true)             \
         && (bash <(curl -Ls https://coverage.codacy.com/get.sh) || true) \
     ' 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -147,22 +147,14 @@
         <!-- jSQL purpose -->
         
         <!-- Standalone Nashorn build compatible with jdk11 -->
-        <dependency>
-            <groupId>org.openjdk.nashorn</groupId>
-            <artifactId>nashorn-core</artifactId>
-            <version>15.2</version>
-        </dependency>
+        
 
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.13.1</version>
-        </dependency>
+        
 
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -181,196 +173,53 @@
             <version>1.0.3</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.27</version>
-        </dependency>
-    
-        <!-- Log4j2 -->
+        
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
         
         
-        <!-- Test purpose -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-websocket</artifactId>
-            <scope>test</scope>
-        </dependency>
         
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-messaging</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+        
+        
+        
+        
 
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-messaging</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId> 
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>1.0.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <scope>test</scope>
-        </dependency>
         
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-websocket</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>webjars-locator-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>sockjs-client</artifactId>
-            <version>1.0.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>stomp-websocket</artifactId>
-            <version>2.3.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>bootstrap</artifactId>
-            <version>3.3.7</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>jquery</artifactId>
-            <version>3.1.1-1</version>
-            <scope>test</scope>
-        </dependency>
         
-        <dependency>
-          <groupId>dnsjava</groupId>
-          <artifactId>dnsjava</artifactId>
-          <version>3.3.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>5.6.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>5.6.0</version>
-            <scope>test</scope>
-        </dependency>
         
-        <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-spring-boot-starter</artifactId>
-            <version>5.0.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-java-tools</artifactId>
-            <version>5.2.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphiql-spring-boot-starter</artifactId>
-            <version>5.0.2</version>
-            <scope>test</scope>
-        </dependency>
         
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
         
-        <!-- Spock -->
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-test-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
             <version>1.3-groovy-2.5</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <!--Only necessary for surefire to run spock tests during the 
-                maven build -->
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Spring -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web-services</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>wsdl4j</groupId>
-            <artifactId>wsdl4j</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Hibernate -->
+        
+        
+        
+        
+        
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
@@ -381,23 +230,13 @@
             <artifactId>hibernate-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-c3p0</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- JUnit -->
+        
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <scope>test</scope>
-        </dependency>
+        
         <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
@@ -405,58 +244,16 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.jcabi</groupId>
-            <artifactId>jcabi-log</artifactId>
-            <version>0.18.1</version>
-            <scope>test</scope>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- JDBC drivers -->
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>mssql-jdbc</artifactId>
-            <version>8.2.1.jre8</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.gwenn</groupId>
-            <artifactId>sqlite-dialect</artifactId>
-            <version>0.1.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.neo4j.driver</groupId>
-            <artifactId>neo4j-java-driver</artifactId>
-            <version>4.0.1</version>
-            <scope>test</scope>
-        </dependency>
+        
+        
+        
+        
+        
+        
+        
+        
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-jdbc-driver</artifactId>
@@ -469,34 +266,11 @@
 <!--             <version>10.2.2.8874</version> -->
 <!--             <scope>test</scope> -->
 <!--         </dependency> -->
-        <dependency>
-            <groupId>com.ibm.db2</groupId>
-            <artifactId>jcc</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <!-- Version 2.5.1 fails on test listValues() -->
-            <version>2.5.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbyclient</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbynet</artifactId>
-            <version>10.14.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <scope>test</scope>
-        </dependency>
+        
+        
+        
+        
+        
             
 <!--         <dependency> -->
 <!--             <groupId>altibase</groupId> -->

--- a/view/pom.xml
+++ b/view/pom.xml
@@ -29,32 +29,13 @@
             <version>v0.85</version>
         </dependency>
 
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
-        </dependency>
+        
 
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-swing-junit</artifactId>
-            <version>3.17.1</version>
-            <scope>test</scope>
-        </dependency>
         
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>3.9.0</version>
-            <scope>test</scope>
-        </dependency>
         
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>4.1.0</version>
-            <scope>test</scope>
-        </dependency>
+        
+        
+        
         
     </dependencies>
     


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
jsql-injection
jsql-model
{groupId='org.openjdk.nashorn', artifactId='nashorn-core'}
{groupId='org.jsoup', artifactId='jsoup'}
{groupId='org.yaml', artifactId='snakeyaml'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
{groupId='ch.qos.logback', artifactId='logback-classic'}
{groupId='org.springframework', artifactId='spring-websocket'}
{groupId='org.springframework', artifactId='spring-messaging'}
{groupId='com.fasterxml.jackson.core', artifactId='jackson-core'}
{groupId='org.springframework.security', artifactId='spring-security-messaging'}
{groupId='com.fasterxml.jackson.core', artifactId='jackson-databind'}
{groupId='io.projectreactor', artifactId='reactor-core'}
{groupId='com.github.javafaker', artifactId='javafaker'}
{groupId='com.google.code.gson', artifactId='gson'}
{groupId='org.springframework.boot', artifactId='spring-boot-starter-websocket'}
{groupId='org.webjars', artifactId='webjars-locator-core'}
{groupId='org.webjars', artifactId='sockjs-client'}
{groupId='org.webjars', artifactId='stomp-websocket'}
{groupId='org.webjars', artifactId='bootstrap'}
{groupId='org.webjars', artifactId='jquery'}
{groupId='dnsjava', artifactId='dnsjava'}
{groupId='net.java.dev.jna', artifactId='jna'}
{groupId='net.java.dev.jna', artifactId='jna-platform'}
{groupId='com.graphql-java', artifactId='graphql-spring-boot-starter'}
{groupId='com.graphql-java', artifactId='graphql-java-tools'}
{groupId='com.graphql-java', artifactId='graphiql-spring-boot-starter'}
{groupId='org.springframework.boot', artifactId='spring-boot-starter-test'}
{groupId='org.codehaus.groovy', artifactId='groovy-test-junit5'}
{groupId='org.junit.vintage', artifactId='junit-vintage-engine'}
{groupId='org.springframework.boot', artifactId='spring-boot-starter-web'}
{groupId='org.springframework.boot', artifactId='spring-boot-starter-security'}
{groupId='org.springframework.boot', artifactId='spring-boot-starter-web-services'}
{groupId='wsdl4j', artifactId='wsdl4j'}
{groupId='org.hibernate', artifactId='hibernate-c3p0'}
{groupId='org.junit.platform', artifactId='junit-platform-runner'}
{groupId='com.jcabi', artifactId='jcabi-log'}
{groupId='org.awaitility', artifactId='awaitility'}
{groupId='com.h2database', artifactId='h2'}
{groupId='mysql', artifactId='mysql-connector-java'}
{groupId='org.postgresql', artifactId='postgresql'}
{groupId='com.microsoft.sqlserver', artifactId='mssql-jdbc'}
{groupId='org.xerial', artifactId='sqlite-jdbc'}
{groupId='com.github.gwenn', artifactId='sqlite-dialect'}
{groupId='org.neo4j.driver', artifactId='neo4j-java-driver'}
{groupId='com.ibm.db2', artifactId='jcc'}
{groupId='org.hsqldb', artifactId='hsqldb'}
{groupId='org.apache.derby', artifactId='derbyclient'}
{groupId='org.apache.derby', artifactId='derbynet'}
{groupId='com.oracle.ojdbc', artifactId='ojdbc8'}
{groupId='org.apache.commons', artifactId='commons-text'}
jsql-view
{groupId='commons-io', artifactId='commons-io'}
{groupId='org.assertj', artifactId='assertj-swing-junit'}
{groupId='org.mockito', artifactId='mockito-inline'}
{groupId='org.awaitility', artifactId='awaitility'}
{groupId='org.apache.commons', artifactId='commons-text'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
