### PR TITLE
Create workaround to resolve problem with release 2.4.0

### DIFF
--- a/build-tools/src/main/resources/site.xml
+++ b/build-tools/src/main/resources/site.xml
@@ -7,11 +7,13 @@
     <skin>
         <groupId>io.github.devacfr.maven.skins</groupId>
         <artifactId>reflow-maven-skin</artifactId>
-        <version>${site.skin.version}</version>
+        <version>${this.reflow-maven-skin.version}</version>
     </skin>
 
     <custom>
         <reflowSkin>
+            <absoluteResourceURL>${this.url}</absoluteResourceURL>
+             <localResources>false</localResources>
             <theme>bootswatch-slate</theme>
             <header type="banner" enabled="false" />
             <titleTemplate>%2$s - jSQL Injection Maven Site</titleTemplate>

--- a/pom.xml
+++ b/pom.xml
@@ -69,14 +69,11 @@
         <!-- disabled on specific engine -->
         <parallel.enabled>true</parallel.enabled>
 
-        <!-- menu not working with 2.3.5 -->
-        <site.skin.version>2.4.0</site.skin.version>
-        <!-- menu not working with 2.3.4 -->
-        <reflow-velocity-tools.version>2.4.0</reflow-velocity-tools.version>
+        <reflow-maven-skin.version>3.0.0-SNAPSHOT</reflow-maven-skin.version>
     </properties>
 
     <!-- required to avoid error: Exception calling reference $config at META-INF/maven/site.vm -->
-    <url>https://ron190.github.io/jsql-injection/</url>
+    <url>https://ron190.github.io/jsql-injection</url>
     <!-- publish site:stage from /staging to GitHub -->
     <!-- settings.xml with user/pass and server id:github added by actions/setup-java -->
     <distributionManagement>
@@ -464,7 +461,7 @@
                     <dependency>
                         <groupId>io.github.devacfr.maven.skins</groupId>
                         <artifactId>reflow-velocity-tools</artifactId>
-                        <version>${reflow-velocity-tools.version}</version>
+                        <version>${reflow-maven-skin.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
The current change in PR is just a workaround of following problems:

* $resourcePath property when absoluteResourceUrl is empty or null.
* Bootstrap cdn url is wrong.

Next step:
- I will create new release 2.4.1 and 2.3.6
- Add local resources if you want?
- If you want help, we can talk about that on Gitter or other chat as your prefer.

PS: I'm working to Bootstrap 5 upgrade, this mainly means that you don't need to focus on theme's feature (Light/Dark).