### PR TITLE
fix: add null check for subscriber view before canceling subscription

### DIFF
--- a/view/src/main/java/com/jsql/view/swing/manager/ManagerScan.java
+++ b/view/src/main/java/com/jsql/view/swing/manager/ManagerScan.java
@@ -183,8 +183,12 @@ public class ManagerScan extends AbstractManagerList {
             Thread.currentThread().interrupt();
         }
 
-        // Display result only in console
-        MediatorHelper.frame().getSubscriberView().getSubscription().cancel();
+        // Display result only in console — guard against null subscription
+        var subView = MediatorHelper.frame().getSubscriberView();
+        var sub = subView != null ? subView.getSubscription() : null;
+        if (sub != null) {
+            sub.cancel();
+        }
         var subscriberScan = new SubscriberScan();
         MediatorHelper.model().subscribe(subscriberScan);
 


### PR DESCRIPTION
Prevent NullPointerException when getSubscriberView() or getSubscription() returns null.

Fixes #96495